### PR TITLE
feat(compression): add mget and mset commands support for compression

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BedrockStreaming/cache-db

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ m6web_redis:
             prefix: raoul\           # prefix to use
             timeout:   2             # timeout in second (float)
             read_write_timeout: 1.2  # read write timeout in seconds (float)
-            compress: true           # compress/uncompress data sent/retrieved from redis using gzip, only method SET, SETEX, SETNX and GET are supported
+            compress: true           # compress/uncompress data sent/retrieved from redis using gzip, only method SET, SETEX, SETNX, GET, MGET and MSET are supported
         sharded:
             servers: ["first", "second"]
             prefix: raaaoul\

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.4",
         "predis/predis": "^1.1.1",
         "doctrine/cache": "~1.3",
-        "b1rdex/predis-compressible": "^0.3.0"
+        "b1rdex/predis-compressible": "^0.5.0"
     },
     "require-dev": {
         "m6web/php-cs-fixer-config": "^1.0",

--- a/src/CacheAdapters/M6WebGuzzleHttp.php
+++ b/src/CacheAdapters/M6WebGuzzleHttp.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace M6Web\Bundle\RedisBundle\CacheAdapters;
 
-use M6Web\Bundle\RedisBundle\Redis\RedisClient;
 use M6Web\Bundle\GuzzleHttpBundle\Cache\CacheInterface;
+use M6Web\Bundle\RedisBundle\Redis\RedisClient;
 
 /**
  * Redis cache adapter for M6WebGuzzleHttp client

--- a/src/CacheAdapters/RedisCacheItemPoolAdapter.php
+++ b/src/CacheAdapters/RedisCacheItemPoolAdapter.php
@@ -5,28 +5,22 @@ declare(strict_types=1);
 namespace M6Web\Bundle\RedisBundle\CacheAdapters;
 
 use M6Web\Bundle\RedisBundle\Redis\RedisClient;
-use Symfony\Component\Cache\CacheItem;
-use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\CacheItem;
 
 /**
  * Class RedisCacheItemPoolAdapter
  */
 class RedisCacheItemPoolAdapter extends RedisClient implements CacheItemPoolInterface
 {
-    /**
-     * @var \Closure
-     */
+    /** @var \Closure */
     private $createCacheItem;
 
-    /**
-     * @var \Closure
-     */
+    /** @var \Closure */
     private $getItemLifeTime;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $transactionInProgress = false;
 
     /**
@@ -124,8 +118,6 @@ class RedisCacheItemPoolAdapter extends RedisClient implements CacheItemPoolInte
     }
 
     /**
-     * @param CacheItemInterface $item
-     *
      * @return bool
      */
     public function save(CacheItemInterface $item)

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace M6Web\Bundle\RedisBundle\Connection;
 
-use Predis\Connection\StreamConnection as PredisStreamConnection;
 use Predis\Connection\ConnectionException;
+use Predis\Connection\StreamConnection as PredisStreamConnection;
 
 class StreamConnection extends PredisStreamConnection
 {

--- a/src/DataCollector/RedisDataCollector.php
+++ b/src/DataCollector/RedisDataCollector.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace M6Web\Bundle\RedisBundle\DataCollector;
 
-use Symfony\Component\HttpKernel\DataCollector\DataCollector;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Request;
 use M6Web\Bundle\RedisBundle\EventDispatcher\RedisEvent;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 
 /**
  * Handle datacollector for redis
@@ -25,8 +25,8 @@ class RedisDataCollector extends DataCollector
     /**
      * Collect the data
      *
-     * @param Request $request The request object
-     * @param Response $response The response object
+     * @param Request         $request   The request object
+     * @param Response        $response  The response object
      * @param \Throwable|null $exception An exception
      */
     public function collect(Request $request, Response $response, ?\Throwable $exception = null)

--- a/src/DependencyInjection/M6WebRedisExtension.php
+++ b/src/DependencyInjection/M6WebRedisExtension.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace M6Web\Bundle\RedisBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -87,8 +87,6 @@ class M6WebRedisExtension extends Extension
      * @param array  $clientServers array of servers defined for a client
      * @param string $clientAlias   alias of the client
      *
-     * @return array
-     *
      * @throws \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     protected function getServers(array $servers, array $clientServers, string $clientAlias): array
@@ -133,8 +131,6 @@ class M6WebRedisExtension extends Extension
      * select an alias for the extension
      *
      * trick allowing bypassing the Bundle::getContainerExtension check on getAlias
-     *
-     * @return string
      */
     public function getAlias(): string
     {

--- a/src/Profile/CompressionProfile.php
+++ b/src/Profile/CompressionProfile.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace M6Web\Bundle\RedisBundle\Profile;
 
+use B1rdex\PredisCompressible\Command\StringGet;
+use B1rdex\PredisCompressible\Command\StringGetMultiple;
+use B1rdex\PredisCompressible\Command\StringSet;
+use B1rdex\PredisCompressible\Command\StringSetExpire;
+use B1rdex\PredisCompressible\Command\StringSetMultiple;
+use B1rdex\PredisCompressible\Command\StringSetPreserve;
 use B1rdex\PredisCompressible\Compressor\GzipCompressor;
 use B1rdex\PredisCompressible\CompressProcessor;
 use Predis\Profile\RedisProfile;
@@ -11,18 +17,13 @@ use Predis\Profile\RedisProfile;
 class CompressionProfile extends RedisProfile
 {
     /**
-     * Strings with length > 2048 bytes will be compressed
-     */
-    const DEFAULT_THRESHOLD = 1024;
-
-    /**
      * {@inheritdoc}
      */
     public function createCommand($commandID, array $arguments = [])
     {
         $command = parent::createCommand($commandID, $arguments);
 
-        $compressor = new GzipCompressor(self::DEFAULT_THRESHOLD);
+        $compressor = new GzipCompressor();
         $compressProcessor = new CompressProcessor($compressor);
         $compressProcessor->process($command);
 
@@ -32,10 +33,12 @@ class CompressionProfile extends RedisProfile
     protected function getSupportedCommands()
     {
         return [
-            'SET' => 'B1rdex\PredisCompressible\Command\StringSet',
-            'SETEX' => 'B1rdex\PredisCompressible\Command\StringSetExpire',
-            'SETNX' => 'B1rdex\PredisCompressible\Command\StringSetPreserve',
-            'GET' => 'B1rdex\PredisCompressible\Command\StringGet',
+            'SET' => StringSet::class,
+            'SETEX' => StringSetExpire::class,
+            'SETNX' => StringSetPreserve::class,
+            'GET' => StringGet::class,
+            'MSET' => StringSetMultiple::class,
+            'MGET' => StringGetMultiple::class,
         ];
     }
 

--- a/src/Redis/RedisClient.php
+++ b/src/Redis/RedisClient.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace M6Web\Bundle\RedisBundle\Redis;
 
+use M6Web\Bundle\RedisBundle\EventDispatcher\RedisEvent;
 use Predis\Client as PredisClient;
 use Predis\Command\CommandInterface;
-use M6Web\Bundle\RedisBundle\EventDispatcher\RedisEvent;
 use Predis\Profile\Factory;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -74,7 +74,7 @@ class RedisClient extends PredisClient
             $event->setCommand($command->getId());
             $event->setExecutionTime($time);
             $event->setArguments($command->getArguments());
-            $this->eventDispatcher->dispatch($event,self::DEFAULT_EVENT);
+            $this->eventDispatcher->dispatch($event, self::DEFAULT_EVENT);
             if (!is_null($this->eventName)) {
                 $this->eventDispatcher->dispatch($event, $this->eventName);
             }

--- a/src/Redis/RedisSessionHandler.php
+++ b/src/Redis/RedisSessionHandler.php
@@ -22,8 +22,6 @@ class RedisSessionHandler implements \SessionHandlerInterface
 
     /**
      * getter for the redis object
-     *
-     * @return ClientInterface
      */
     public function getRedis(): ClientInterface
     {

--- a/src/Tests/Units/CacheAdapters/RedisCacheItemPoolAdapter.php
+++ b/src/Tests/Units/CacheAdapters/RedisCacheItemPoolAdapter.php
@@ -44,7 +44,6 @@ class RedisCacheItemPoolAdapter extends AbstractTest
         ;
     }
 
-
     public function testExpirableItem()
     {
         $this

--- a/src/Tests/Units/DependencyInjection/M6WebRedisExtension.php
+++ b/src/Tests/Units/DependencyInjection/M6WebRedisExtension.php
@@ -4,23 +4,19 @@ declare(strict_types=1);
 
 namespace M6Web\Bundle\RedisBundle\Tests\Units\DependencyInjection;
 
+use M6Web\Bundle\RedisBundle\DependencyInjection\M6WebRedisExtension as BaseM6WebRedisExtension;
 use mageekguy\atoum;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use M6Web\Bundle\RedisBundle\DependencyInjection\M6WebRedisExtension as BaseM6WebRedisExtension;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class M6WebRedisExtension extends atoum\test
 {
-    /**
-     * @var BaseM6WebRedisExtension
-     */
+    /** @var BaseM6WebRedisExtension */
     protected $extension;
 
-    /**
-     * @var ContainerBuilder
-     */
+    /** @var ContainerBuilder */
     protected $container;
 
     protected function initContainer()
@@ -34,8 +30,7 @@ class M6WebRedisExtension extends atoum\test
     }
 
     /**
-     * @param ContainerBuilder $container
-     * @param                  $resource
+     * @param $resource
      */
     protected function loadConfiguration(ContainerBuilder $container, $resource)
     {

--- a/src/Tests/Units/Mock/StreamConnectionMock.php
+++ b/src/Tests/Units/Mock/StreamConnectionMock.php
@@ -32,7 +32,7 @@ class StreamConnectionMock extends \Predis\Connection\StreamConnection
     {
         $methodName = strtolower($command->getId());
 
-        if (!method_exists('M6Web\Component\RedisMock\RedisMock', $methodName)) {
+        if (!method_exists(RedisMock::class, $methodName)) {
             throw new UnsupportedException(sprintf('Redis command `%s` is not supported by RedisMock.', $methodName));
         }
 

--- a/src/Tests/Units/Mock/StreamConnectionMock.php
+++ b/src/Tests/Units/Mock/StreamConnectionMock.php
@@ -11,9 +11,7 @@ use Predis\Connection\ParametersInterface;
 
 class StreamConnectionMock extends \Predis\Connection\StreamConnection
 {
-    /**
-     * @var RedisMock
-     */
+    /** @var RedisMock */
     protected $redisMock;
 
     /**

--- a/src/Tests/Units/Redis/RedisClient.php
+++ b/src/Tests/Units/Redis/RedisClient.php
@@ -48,7 +48,7 @@ class RedisClient extends AbstractTest
     protected function getEventDispatcherMock()
     {
         $mock = new \Mock\Symfony\Component\EventDispatcher\EventDispatcher();
-        $mock->getMockController()->dispatch = function(): object { return new \StdClass; };
+        $mock->getMockController()->dispatch = function (): object { return new \StdClass(); };
 
         return $mock;
     }

--- a/src/Tests/Units/Redis/RedisClient.php
+++ b/src/Tests/Units/Redis/RedisClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace M6Web\Bundle\RedisBundle\Tests\Units\Redis;
 
 use M6Web\Bundle\RedisBundle\Tests\Units\AbstractTest;
+use M6Web\Bundle\RedisBundle\Tests\Units\Mock\StreamConnectionMock;
 
 /**
  * Test compute last modified date
@@ -19,7 +20,7 @@ class RedisClient extends AbstractTest
     public function testDecoratorCalls($srcMethod, $srcArgs)
     {
         $redisClient = $this->newTestedInstance('tcp://127.0.0.1', [
-            'connections' => ['tcp' => '\M6Web\Bundle\RedisBundle\Tests\Units\Mock\StreamConnectionMock'],
+            'connections' => ['tcp' => StreamConnectionMock::class],
         ]);
         $redisClient->setEventDispatcher($eventDispatcher = $this->getEventDispatcherMock());
         $this
@@ -39,6 +40,8 @@ class RedisClient extends AbstractTest
             ['set',    ['foo', 'bar']],
             ['ttl',    ['foo']],
             ['del',    ['raoul']],
+            ['mget',   [[['foo', 'bar']]]],
+            ['mset',   [['foo' => 'fighters'], ['bar' => 'baz']]],
         ];
     }
 

--- a/src/Tests/Units/Redis/RedisSessionHandler.php
+++ b/src/Tests/Units/Redis/RedisSessionHandler.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace M6Web\Bundle\RedisBundle\Tests\Units\Redis;
 
-use mageekguy\atoum;
-use M6Web\Component\RedisMock\RedisMockFactory;
-use M6Web\Bundle\RedisBundle\Redis\RedisSessionHandler as BaseRedisSessionHandler;
 use M6Web\Bundle\RedisBundle\Redis\RedisClient as BaseRedis;
+use M6Web\Bundle\RedisBundle\Redis\RedisSessionHandler as BaseRedisSessionHandler;
+use M6Web\Component\RedisMock\RedisMockFactory;
+use mageekguy\atoum;
 
 /**
  * Class RedisSessionHandler


### PR DESCRIPTION
## Why?

The bundle can gain from supporting the compression for the `mget` and `mset` redis commands.

## How ?

Support added for `mget` and `mset` commands for compression.
This has been achievable by updating the `b1rdex/predis-compressible` dependency to its latest release.
All the changes associated to this are available in [the following commit](https://github.com/BedrockStreaming/RedisBundle/pull/61/commits/8a871b0ed6ef2aa3f010fb63871652a788b53e46).