### PR TITLE
feat(command): add del command support when compressing is enabled

### DIFF
--- a/src/Profile/CompressionProfile.php
+++ b/src/Profile/CompressionProfile.php
@@ -12,6 +12,7 @@ use B1rdex\PredisCompressible\Command\StringSetMultiple;
 use B1rdex\PredisCompressible\Command\StringSetPreserve;
 use B1rdex\PredisCompressible\Compressor\GzipCompressor;
 use B1rdex\PredisCompressible\CompressProcessor;
+use Predis\Command\KeyDelete;
 use Predis\Profile\RedisProfile;
 
 class CompressionProfile extends RedisProfile
@@ -39,6 +40,7 @@ class CompressionProfile extends RedisProfile
             'GET' => StringGet::class,
             'MSET' => StringSetMultiple::class,
             'MGET' => StringGetMultiple::class,
+            'DEL' => KeyDelete::class,
         ];
     }
 

--- a/src/Tests/Units/Redis/RedisClient.php
+++ b/src/Tests/Units/Redis/RedisClient.php
@@ -42,6 +42,7 @@ class RedisClient extends AbstractTest
             ['del',    ['raoul']],
             ['mget',   [[['foo', 'bar']]]],
             ['mset',   [['foo' => 'fighters'], ['bar' => 'baz']]],
+            ['del',   ['foo']],
         ];
     }
 


### PR DESCRIPTION
## Why?

The bundle can gain from supporting the `del` redis command when the compression is enabled.

## How ?

Support added for `del` commands when compression is enabled.